### PR TITLE
Cleanup block reference underline

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.9) 1px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;

--- a/latte.css
+++ b/latte.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.35) 1.5px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;

--- a/macchiato.css
+++ b/macchiato.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.35) 1.5px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;

--- a/nord.css
+++ b/nord.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.35) 1.5px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;

--- a/onedark.css
+++ b/onedark.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.35) 1.5px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;

--- a/sepia.css
+++ b/sepia.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.35) 1.5px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;

--- a/xiaobot.css
+++ b/xiaobot.css
@@ -1702,14 +1702,16 @@ a.page-ref:hover {
     border-bottom-style: dashed;
     border-bottom-color: hsl(var(--cl-text-color), 0.35);
     */
-    text-decoration: underline dotted hsl(var(--cl-text-color), 0.35);
-    text-underline-offset: 4px;
     color: hsl(var(--cl-text-color), 0.9);
     background-color: hsl(var(--cl-accent), 0);
     border-bottom: 0px;
     border-radius: 0px;
     opacity: 1;
     /* transition: 0.2s; */
+}
+:not(.whiteboard-shape) .block-ref span {
+    border-bottom: dotted hsl(var(--cl-text-color), 0.35) 1.5px;
+    padding-bottom: 2.5px;
 }
 .block-ref:hover {
     cursor: pointer;


### PR DESCRIPTION
 - One continuous underline through the block.
 - Task time tracking entry is no longer underlined

Before:
<img width="446" alt="image" src="https://github.com/henices/logseq-flow-nord/assets/1426795/105aacf9-92d1-4aa8-a5d2-f8ba16e384ce">


After:
<img width="451" alt="image" src="https://github.com/henices/logseq-flow-nord/assets/1426795/f967f60b-b9d3-42e8-ba98-dc4cc7320f52">


---

This one is a bit of an opinionated change so feel free to dismiss it if it doesn't fit your style.

My thought is that the entire block is referenced (including priority and checkbox) so it should all be underlined. I also think the single continuous line looks a bit cleaner